### PR TITLE
fix: Disable dynamic inventory

### DIFF
--- a/scripts/python/software_hosts.py
+++ b/scripts/python/software_hosts.py
@@ -796,7 +796,7 @@ def get_ansible_inventory():
 
     heading1("Software hosts inventory setup\n")
 
-    dynamic_inventory = _get_dynamic_inventory()
+    dynamic_inventory = None
 
     # If dynamic inventory contains clients prompt user to use it
     if (dynamic_inventory is not None and


### PR DESCRIPTION
A problem can occur if a power-up config file is present without a
generated inventory file. Power-up provisioning is not yet supported in
the software-installer branch so for now the dynamic inventory check can
simply be disabled.