### PR TITLE
fix: Use '/srv/pup' conductor binary for localhost

### DIFF
--- a/software/wmla121.py
+++ b/software/wmla121.py
@@ -168,6 +168,7 @@ class software(object):
         else:
             self.root_dir = f'{self.root_dir_nginx}/{self.my_name}-{arch}/'
 
+        self.sw_vars['root_dir'] = self.root_dir
         self.sw_vars['python_executable_local'] = get_venv_path() + "/" + PYTHON_EXE
         self.sw_vars['scripts_path_local'] = get_scripts_path()
         self.sw_vars['python_path_local'] = get_python_path()

--- a/software/wmla121_ansible/install_spectrum_conductor_with_spark.yml
+++ b/software/wmla121_ansible/install_spectrum_conductor_with_spark.yml
@@ -10,7 +10,7 @@
   delegate_to: localhost
   register: host_ip
 
-- name: Download installer binary
+- name: Download installer binary to remote hosts
   get_url:
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
@@ -18,6 +18,7 @@
     url: "http://{{ host_ip.stdout }}/{{ file }}"
     dest: "{{ ansible_remote_dir }}"
     timeout: 300
+  when: hostvars['localhost']['ansible_fqdn'] != ansible_host
   become: yes
 
 - name: Include configuration environment variables
@@ -28,6 +29,11 @@
 - name: Get enterprise license filename from software-vars.yml
   set_fact:
     filename: "{{ content_files['spectrum-conductor'].split('/')[-1] }}"
+
+- name: Set local path if installer is part of cluster
+  set_fact:
+    ansible_remote_dir: "/srv/pup/wmla121-ppc64le/spectrum-conductor"
+  when: hostvars['localhost']['ansible_fqdn'] == ansible_host
 
 - name: Install IBM Spectrum Conductor
   shell: "{{ ansible_remote_dir }}/{{ filename }} --quiet"

--- a/software/wmla121_ansible/install_spectrum_conductor_with_spark.yml
+++ b/software/wmla121_ansible/install_spectrum_conductor_with_spark.yml
@@ -32,7 +32,7 @@
 
 - name: Set local path if installer is part of cluster
   set_fact:
-    ansible_remote_dir: "/srv/pup/wmla121-ppc64le/spectrum-conductor"
+    ansible_remote_dir: "{{ root_dir }}spectrum-conductor"
   when: hostvars['localhost']['ansible_fqdn'] == ansible_host
 
 - name: Install IBM Spectrum Conductor


### PR DESCRIPTION
When running a software 'self-install' skip copying the conductor
install binary to a new folder (via http get in order to re-use logic
for remote nodes). Extra logic is added to be able to use the existing
binary in the http directory.